### PR TITLE
Update Kiwisolver to Version 1.3.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.1" %}
+{% set version = "1.3.2" %}
 
 package:
   name: kiwisolver
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/k/kiwisolver/kiwisolver-{{ version }}.tar.gz
-  sha256: 950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248
+  sha256: fc4453705b81d03568d5b808ad8f09c77c47534f6ac2e72e733f9ca4714aa75c
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,13 +21,18 @@ requirements:
     - pip
     - setuptools
     - cppy
-
+    - wheel
   run:
-    - python
+    - python >=3.7
 
 test:
   imports:
     - kiwisolver
+  requires:
+    - pip
+    - python <3.10
+  commands:
+    - pip check
 
 about:
   home: https://github.com/nucleic/kiwi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
   sha256: fc4453705b81d03568d5b808ad8f09c77c47534f6ac2e72e733f9ca4714aa75c
 
 build:
+  skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
 
@@ -20,7 +21,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - cppy
+    - cppy >=1.1.0
     - wheel
   run:
     - python >=3.7


### PR DESCRIPTION

1. check the upstream
https://github.com/nucleic/kiwi/tree/1.3.2.rc1

2. check the pinnings
https://github.com/nucleic/kiwi/blob/1.3.2.rc1/setup.py

Correct the `python` pinnings 
https://github.com/nucleic/kiwi/blob/1.3.2.rc1/setup.py#L90

3. check changelogs
https://github.com/nucleic/kiwi/blob/main/releasenotes.rst

There are no breaking changes mentioned in the change log
only features changes

4. additional research
https://github.com/conda-forge/kiwisolver-feedstock/issues

There are no open issues at the time of the review

5. verify dev_url
    https://github.com/nucleic/kiwi

6. verify doc_url
    https://pypi.python.org/pypi/kiwisolver

7. added pip to the test section
8. verify the test section
9. additional tests

In order to test the `kiwisolver` package version `1.3.2` the following command was used:
`conda build kiwisolver-feedstock --test` 
The test result was the following:
`All tests passed`

In additional the `enaml` package was used to test the `kiwisolver` package version `1.3.2` 
The pinnings in `enaml` were modified to reflect the latest changes.  
The following test was conducted:
`conda build enaml-feedstock --test` 
The test result was the following:
`All tests passed`

Based on the research findings and on the test results we can conclude that it is safe to update `kiwisolver` to version `1.3.2`
