### PR TITLE
Update `Kiwisolver` to version `1.3.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,8 @@ source:
   sha256: fc4453705b81d03568d5b808ad8f09c77c47534f6ac2e72e733f9ca4714aa75c
 
 build:
+  # the earliest supported version of python is python 3.7
+  # https://github.com/nucleic/kiwi/blob/1.3.2/setup.py#L90
   skip: True  # [py<37]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,13 @@ requirements:
     - cppy >=1.1.0
     - wheel
   run:
-    - python >=3.7
+    - python
 
 test:
   imports:
     - kiwisolver
   requires:
     - pip
-    - python <3.10
   commands:
     - pip check
 


### PR DESCRIPTION
  `kiwisolver` version `1.3.2`
1. - [x] check the upstream
    https://github.com/nucleic/kiwi/tree/1.3.2

2. - [x] check the pinnings

    https://github.com/nucleic/kiwi/blob/1.3.2/setup.py

    minimum supported version of python is `python` `3.7`

    https://github.com/nucleic/kiwi/blob/1.3.2/setup.py#L90

3. - [x] check the changelogs

    https://github.com/nucleic/kiwi/blob/1.3.2/releasenotes.rst

    `python` version `3.6` and older are no longer supported
    `python` version `3.10` is now supported

    Direct asses to `ob_type` in `C-API` has been removed, it is recommended to use `Py_TYPE` instead

4. - [x] additional research
    https://github.com/conda-forge/kiwisolver-feedstock/issues

    At the time of the review there are no open issues mentioned in conda forge

5. - [x] verify dev_url
    https://github.com/nucleic/kiwi

6. - [x] verify doc_url
    https://pypi.python.org/pypi/kiwisolver

7. - [x] license is spdx compliant
    https://spdx.org/licenses/BSD-3-Clause.html
8. - [x] license family
    https://spdx.org/licenses/BSD-3-Clause.html
    (BSD)
9. - [x] verify the build number
    The build number is set to zero
10. - [x] verify setuptools
    Setuptools is in the recipe
11. - [x] verify wheel
    Wheel is in the recipe
12. - [x] pip in the test section
13. - [x] veriy the test section

Results:
- All Passed


Based on the research findings and the results we can conclude
that it is safe to update `kiwisolver` to version `1.3.2`
